### PR TITLE
avoid mixed content for github API

### DIFF
--- a/viewer/js/icon-list.js
+++ b/viewer/js/icon-list.js
@@ -1,4 +1,4 @@
-var BASE_GIT_URI = "http://api.github.com/repos/FirefoxUX/firefox-svg-icons";
+var BASE_GIT_URI = "https://api.github.com/repos/FirefoxUX/firefox-svg-icons";
 var IconList = {
   requestCache: false,
   getAllDirectories: function() {


### PR DESCRIPTION
Mixed content is blocked by default on Nightly.